### PR TITLE
convert.js edits, fixes #11

### DIFF
--- a/convert.js
+++ b/convert.js
@@ -142,6 +142,7 @@
 
     convert.Metric = function(data, source, target){
         if(isNumber(data)){
+			if (!source || !target) return false;
             source = source.toLowerCase();
             if (source === 'cm') return cm(data, target);
             else if (source === 'km') return km(data, target);
@@ -211,6 +212,7 @@
 
     convert.DataUnits = function(data, source, target){
         if(isNumber(data)){
+			if (!source || !target) return false;
             source = source.toLowerCase();
             if (source === 'byte') return byte(data, target);
             else if (source === 'kb') return kb(data, target);
@@ -249,9 +251,9 @@
         else if (target === 'f') return 0.18333 * (data - 32);
     }
 
-    //Temparature Convert
     convert.Temperature = function(data, source, target) { 
     	if(isNumber(data)){
+			if (!source || !target) return false;
     		source = source.toLowerCase();
     		if (source === 'c') return c(data, target);
             else if (source === 'k') return k(data, target);
@@ -323,6 +325,7 @@
 
     convert.Angle = function(data, source, target) {
         if(isNumber(data)){
+            if (!source || !target) return false;
             source = source.toLowerCase();
             if(source === 'deg') return deg(data, target);
             else if(source === 'rad') return  rad(data, target);
@@ -401,6 +404,7 @@
 
     convert.Time = function(data, source, target) { 
         if(isNumber(data)){
+            if (!source || !target) return false;
             source = source.toLowerCase();
             if (source === 'century') return century(data, target);
             else if (source === 'minute') return minute(data, target);
@@ -456,6 +460,7 @@
 
     convert.Energy = function(data, source, target){
         if(isNumber(data)){
+            if (!source || !target) return false;
             source = source.toLowerCase();
             if (source === 'kj') return kilojoule(data, target);
             else if (source === 'j') return joule(data, target);


### PR DESCRIPTION
Made modifications in the js file to fix the `Cannot read property 'toLowerCase' of undefined` error.

**Usages:**
```
convert.Metric(1);            // false
convert.Metric(1, "cm");      // false
convert.Metric(1, null, "m")  // false
```